### PR TITLE
wip(neptune): initial view with in-vpc and tunneled modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Most settings can be set by creating a custom Docker environment file `src/docke
 * URL base path: `BASE_PATH=my_subpath/` (default `dashboard/`) and `BASE_URL=http://site.com/my_subpath/` (default `http://localhost:8501/dashboard`)
 * Graphistry: `GRAPHISTRY_USERNAME=usr` + `GRAPHISTRY_PASSWORD=pwd` (see `src/envs/graphistry.env` for more, like `GRAPHISTRY_SERVER`)
 * Log level: `LOG_LEVEL=DEBUG` (default `ERROR`)
+* Neptune: Set options in `envs/neptune.env`, and optionally, run through a tunnel outside of the VPC
 
 Advanced edits may also happen in `docker-compose.yml` and `/etc/docker/daemon.json` . 
 

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - "8501:8501"
     volumes:
       - ../python:/apps
+      #- /my_local_path/.ssh/neptune-tunnel.pem:/secrets/neptune-reader.pem
     healthcheck:
       test: ["CMD", "curl", "-Lf", "http://localhost:8501/$BASE_PATH/healthz"]
       interval: 30s

--- a/src/envs/neptune.env
+++ b/src/envs/neptune.env
@@ -1,0 +1,20 @@
+############################################################
+##
+## NEPTUNE
+##
+############################################################
+# We recommend putting edits in docker/.env instead, which overrides this file
+
+
+##----------------------------------------------------------
+
+
+### See https://docs.aws.amazon.com/neptune/latest/userguide/feature-overview-endpoints.html
+#NEPTUNE_READER_PROTOCOL=wss
+#NEPTUNE_READER_HOST=your-neptune-endpoint.com
+#NEPTUNE_READER_PORT=8182
+
+### Optional: Tunnel through an EC2 node in same VPC as Neptune, such as for local dev or remote service
+# Private key: see docker-compose.yml for volume mount of /secrets/neptune-reader.pem
+#NEPTUNE_TUNNEL_HOST=222.222.222.222
+#NEPTUNE_TUNNEL_USER=root

--- a/src/python/requirements-system.txt
+++ b/src/python/requirements-system.txt
@@ -1,2 +1,12 @@
 protobuf==3.13.0
 graphistry==0.11.8
+
+################
+#
+#  Per-DB
+#
+################
+
+### Neptune
+gremlinpython==3.4.8
+sshtunnel==0.1.5

--- a/src/python/views/demo_04_simple/__init__.py
+++ b/src/python/views/demo_04_simple/__init__.py
@@ -60,7 +60,7 @@ def sidebar_area():
 
 # Given filter settings, generate/cache/return dataframes & viz
 @st.cache(suppress_st_warning=True, allow_output_mutation=True)
-def run_filters(num_nodes, num_edges):    
+def run_filters(num_nodes, num_edges):
     nodes_df = pd.DataFrame({ 'n': [x for x in range(0, num_nodes)] })
     edges_df = pd.DataFrame({
         's': [x % num_nodes for x in range(0, num_edges)],

--- a/src/python/views/demo_neptune_01_minimal_gremlin/__init__.py
+++ b/src/python/views/demo_neptune_01_minimal_gremlin/__init__.py
@@ -1,0 +1,166 @@
+import graphistry, os, pandas as pd, streamlit as st
+from components import GraphistrySt, URLParam
+from css import all_css
+from util import getChild
+
+
+### https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-python.html
+from gremlin_python import statics
+from gremlin_python.structure.graph import Graph
+from gremlin_python.process.graph_traversal import __
+from gremlin_python.process.strategies import *
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+
+### Optional: local dev <> VPC [ ec2 proxy <> neptune instance ]
+from sshtunnel import SSHTunnelForwarder
+
+IS_LOCAL_DEV = True
+
+############################################
+#
+#   DASHBOARD SETTINGS
+#
+############################################
+#  Controls how entrypoint.py picks it up
+
+
+app_id = 'app_neptune_01'
+logger = getChild(app_id)
+urlParams = URLParam(app_id)
+
+
+def info():
+    return {
+        'id': app_id,
+        'name': 'app6: neptune'
+    }
+
+
+def run():
+    run_all()
+
+
+############################################
+#
+#   PIPELINE PIECES
+#
+############################################
+
+
+# Have fun!
+def custom_css():
+    all_css()
+    st.markdown(
+        """<style>
+        
+        </style>""",unsafe_allow_html=True)
+
+
+# Given URL params, render left sidebar form and return combined filter settings
+#https://docs.streamlit.io/en/stable/api.html#display-interactive-widgets
+def sidebar_area():
+
+    return { }
+
+
+# Given filter settings, generate/cache/return dataframes & viz
+@st.cache(suppress_st_warning=True, allow_output_mutation=True)
+def run_filters():
+
+    graph = Graph()
+
+    #See docker/.env & envs/neptune.env
+    if not ('NEPTUNE_READER_HOST' in os.environ):
+        raise RuntimeError('Demo requires NEPTUNE_READER_HOST (see envs/neptune.env)')
+
+    cfg = {
+        'NEPTUNE_READER_PROTOCOL': 'wss',
+        'NEPTUNE_READER_HOST': None,
+        'NEPTUNE_READER_PORT': 8182,
+    }
+    for k in cfg.keys():
+        if k in os.environ:
+            cfg[k] = os.environ[k]    
+
+    NEPTUNE_READER_CONN_STR = cfg['NEPTUNE_READER_PROTOCOL'] + '://' + cfg['NEPTUNE_READER_HOST'] + ':' + str(cfg['NEPTUNE_READER_PORT']) + '/gremlin'
+    logger.debug('Using neptune conn str: %s', NEPTUNE_READER_CONN_STR)
+
+    server = None
+    try:
+        if 'NEPTUNE_TUNNEL_HOST' in os.environ:
+            logger.debug('LOCAL_DEV')
+            cfg = {
+                **cfg,
+                'NEPTUNE_TUNNEL_HOST': None,
+                'NEPTUNE_TUNNEL_USER': 'ec2-user'
+            }
+            for k in cfg.keys():
+                if k in os.environ:
+                    cfg[k] = os.environ[k]
+            logger.debug('Tunnel cfg: %s', cfg)
+
+            logger.debug('disabling ssh context')            
+            import ssl
+            ssl._create_default_https_context = ssl._create_unverified_context
+
+            logger.debug('configuring tunnel')            
+            server = SSHTunnelForwarder(
+                (cfg['NEPTUNE_TUNNEL_HOST'], 22),
+                ssh_username=cfg['NEPTUNE_TUNNEL_USER'],
+                ssh_pkey='/secrets/neptune-reader.pem',
+                remote_bind_address=(cfg['NEPTUNE_READER_HOST'], int(cfg['NEPTUNE_READER_PORT'])),
+                local_bind_address=('', 8182)
+            )
+            logger.debug('starting tunnel')            
+            server.start()
+
+            NEPTUNE_READER_CONN_STR= cfg['NEPTUNE_READER_PROTOCOL'] + '://localhost:' + str(server.local_bind_port) + '/gremlin'
+            logger.debug('Tunneled neptune config: %s', NEPTUNE_READER_CONN_STR)
+
+        remoteConn = DriverRemoteConnection(NEPTUNE_READER_CONN_STR, 'g')
+        g = graph.traversal().withRemote(remoteConn)
+
+        logger.debug(('out', g.V().limit(2).toList()))
+        remoteConn.close()
+
+        return { }
+    except Exception as e:
+        logger.error('oops in gremlin', exc_info=True)
+        raise e
+    finally:
+        logger.debug("Cleaning up server if any: %s", not (server is None))
+        if not (server is None):
+            server.stop()
+    
+def main_area():
+    pass
+
+
+############################################
+#
+#   PIPELINE FLOW
+#
+############################################
+
+
+def run_all():
+
+    custom_css()
+    
+    try:
+
+        # Render sidebar and get current settings
+        sidebar_filters = sidebar_area()
+
+        # Compute filter pipeline (with auto-caching based on filter setting inputs)
+        # Selective mark these as URL params as well
+        filter_pipeline_result = run_filters(**sidebar_filters)
+
+        # Render main viz area based on computed filter pipeline results and sidebar settings
+        main_area(**sidebar_filters, **filter_pipeline_result)
+
+    except Exception as exn:
+        st.write('Error loading dashboard')
+        st.write(exn)
+
+    


### PR DESCRIPTION
It's alive!

* template in envs/neptune.env
* viz generation
* Experimental - tunneling: see neptune.env and docker-compose.yml private key


Not in this PR:
* example of how to get all node/edge props via gremlin
* example of working with rdf
* overall docs
* automation for end-to-end example
* dev persona tweaks (local dev, ..)


![image](https://user-images.githubusercontent.com/4249447/91919415-c5633580-ec7a-11ea-9a6c-adb5a212844c.png)
