### PR TITLE
infra(updates): rapids/graphistry/pygraphistry/streamlit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to the graph-app-kit are documented in this file.
+
+The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and all PyGraphistry-specific breaking changes are explictly noted here.
+
+Related changelogs:
+
+Core:
+* [Streamlit](https://docs.streamlit.io/en/stable/changelog.html)
+* [PyGraphistry changelog](https://github.com/graphistry/pygraphistry/blob/master/CHANGELOG.md)
+* [Graphistry core changelog](https://graphistry.zendesk.com/hc/en-us/articles/360033184174-Enterprise-Release-List-Downloads)
+* [RAPIDS changelog](https://github.com/rapidsai/cudf/releases)
+
+Extensions:
+* [Neo4j](https://neo4j.com/release-notes/)
+* [TigerGraph](https://docs.tigergraph.com/faqs/change-log-1)
+* [AWS Neptune](https://docs.aws.amazon.com/neptune/latest/userguide/doc-history.html)
+
+
+## [Development]
+
+### Adding
+
+* TigerGraph
+
+## [2021.02.23]
+
+### Added
+
+* Changelog
+* AMI enumeration script
+
+### Changed
+
+* Versions: Streamlit 0.70 -> 0.77, PyGraphistry 0.14 -> 0.17.2, Graphistry -> 2.35.9 (including AMIs)
+* Dev docs: Tagging, building
+* Graphistry 2.35+ Support: Swaps in old < 2.34-style Caddy 1.x container as Graphistry 2.35's Caddy 2.x is currently tricky for auth reuse
+* Plotter auto-memoizes with `.plot(as_files=True, ...)`
+
+### Breaking
+
+* Default base container now CUDA 11.0
+
+---

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -2,13 +2,26 @@
 
 These instructions are for contributing to this repository. See main README.md for usage.
 
+## Manual
+
+```bash
+cd src/docker
+docker-compose build
+docker-compose up
+```
+
+## Base versions
+
+For faster AWS launches, we:
+- Keep the docker base (docker-compose.yml::GRAPHISTRY_FORGE_BASE_VERSION) in sync w/ AWS version
+- Update aws version (bootstraps/*/graphistry.yml) by finding AMIs via bootstraps/scripts/graphistry-ami-list.sh
 
 ## Automated Builds
 
 Managed via DockerHub automated builds
 
 * Master merge updates tag `latest`
-* Git tags publish to the DockerHub repo for each service
+* Git tags ('v1.2.3') publish to the DockerHub repo for each service
 * Failed builds do not publish
 
 See [current tags](https://hub.docker.com/repository/docker/graphistry/graph-app-kit-st)
@@ -16,5 +29,6 @@ See [current tags](https://hub.docker.com/repository/docker/graphistry/graph-app
 ## Publish
 
 * Docker rebuilds on merge to main
+* Push main tag ('v1.2.3') for building named versions
 * CloudFormation templates upload upon a PR being labeled "publish"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/graphistry/graph-app-kit-st)
+[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/graphistry/graph-app-kit-st)](https://hub.docker.com/r/graphistry/graph-app-kit-st)
 
 [<img src="https://img.shields.io/badge/slack-Graphistry%20chat-yellow.svg?logo=slack">](https://join.slack.com/t/graphistry-community/shared_invite/zt-53ik36w2-fpP0Ibjbk7IJuVFIRSnr6g) 
-![Twitter Follow](https://img.shields.io/twitter/follow/graphistry)
+[![Twitter Follow](https://img.shields.io/twitter/follow/graphistry)](https://twitter.com/graphistry)
 
 # Welcome to graph-app-kit
 
@@ -12,25 +12,27 @@ Turn your graph data into a secure and interactive visual graph app in 15 minute
 
 ## Why
 
-This open source effort puts together patterns the Graphistry team has reused across many graph projects as teams went from Jupyter notebook experiments to deployed analyst tools. Whether building your first graph app, trying an idea,  or wanting to check a reference, this project aims to simplify the process. This means covering pieces like: Easy code editing and deployment, a project stucture ready for teams, built-in authentication, no need for custom JS/CSS at the start, batteries-included dependencies, and fast loading & visualization of large graphs.
+This open source effort puts together patterns the Graphistry team has reused across many graph projects as teams go from code-heavy Jupyter notebook experiments to deploying streamlined analyst tools. Whether building your first graph app, trying an idea, or wanting to check a reference, this project aims to simplify that process. It covers pieces like: Easy code editing and deployment, a project stucture ready for teams, built-in authentication, no need for custom JS/CSS at the start, batteries-included data + library dependencies, and fast loading & visualization of large graphs.
 
 ## Get started
 
-### Quick
+### Quick (Local code)
 
 ```bash
 git clone https://github.com/graphistry/graph-app-kit.git
 cd graph-app-kit/src/docker
 sudo docker-compose build
-# Optional: edit src/docker/.env, docker-compose.yml: Auth, ports, ...
+# Optional: edit src/docker/.env (API accounts), docker-compose.yml: Auth, ports, ...
 sudo docker-compose up -d
 sudo docker-compose logs -f -t --tail=100
-# Add src/python/views/your_custom_view/__init__.py
+# Add dashboards @ src/python/views/<your_custom_view>/__init__.py
 ```
 
-### Guides
+=> `http://localhost:8501/`
 
-1. [Quick launch](docs/setup.md): Preintegrated Docker, Graphistry, Streamlit, Jupyter, RAPIDS.ai (GPU)
+### Quick (Launchers)
+
+1. [AWS Quick launch](docs/setup.md): Preintegrated Docker, Graphistry, Streamlit, Jupyter, RAPIDS.ai (GPU)
   * Variants: [manual launch](docs/setup-manual.md), [Amazon Neptune](docs/neptune.md)
 2. [Add views](docs/views.md)
 3. [Main configurations and extensions](docs/extend.md): Database connectors, authentication, notebook-based editing, and more

--- a/src/bootstraps/core/graphistry.yml
+++ b/src/bootstraps/core/graphistry.yml
@@ -30,28 +30,42 @@ Parameters:
     Default: 'g4dn.xlarge'
     Description: "Enter a RAPIDS.ai-compatible GPU instance type. Ex: g4dn.xlarge"
 
+#2.35.9-11.0
+#Generated with: src/bootstraps/scripts/graphistry-ami-list.sh
 Mappings: 
   RegionMap: 
-    us-east-1: 
-      "HVM64": "ami-0758d945357560324"
-    us-east-2:
-      "HVM64": "ami-088aaa8746bde2e21"
-    us-west-1: 
-      "HVM64": "ami-041526a3d02947394"
-    us-west-2:
-      "HVM64": "ami-01a5481ca3c8d8257"
-    eu-central-1:
-      "HVM64": "ami-0c3e601ddac853aba"
-    eu-west-1: 
-      "HVM64": "ami-0edc0fc6cb4efa908"
-    eu-west-2:
-      "HVM64": "ami-0f351900207433c32"
-    eu-west-3:
-      "HVM64": "ami-00ee1a79360375598"
     eu-north-1:
-      "HVM64": "ami-0c90b099725351632"
+      "HVM64": "ami-020db5b9468605b1b"
+    ap-south-1:
+      "HVM64": "ami-0da292ae7221b4712"
+    eu-west-3:
+      "HVM64": "ami-097617b9ab348bd7d"
+    eu-west-2:
+      "HVM64": "ami-0fe4d7af59713cc8b"
+    eu-west-1:
+      "HVM64": "ami-04c579438e71c9b4e"
+    ap-northeast-2:
+      "HVM64": "ami-0a647fc9d83aaa798"
+    ap-northeast-1:
+      "HVM64": "ami-09408fd12167b1ddc"
     sa-east-1:
-      "HVM64": "ami-09aa432a1a03a1459"
+      "HVM64": "ami-0881a3b8d12b49dd0"
+    ca-central-1:
+      "HVM64": "ami-0046f23296157202d"
+    ap-southeast-1:
+      "HVM64": "ami-04a449007e7a22792"
+    ap-southeast-2:
+      "HVM64": "ami-02a981824c38b66dd"
+    eu-central-1:
+      "HVM64": "ami-010c9a3be1f3ae351"
+    us-east-1:
+      "HVM64": "ami-0322bad99c5e1eec8"
+    us-east-2:
+      "HVM64": "ami-07915b33d57ebde27"
+    us-west-1:
+      "HVM64": "ami-07d59135fe7222642"
+    us-west-2:
+      "HVM64": "ami-0fb7bf940df96836e"
 
 Resources:
   GraphAppKitSecurityGroup:

--- a/src/bootstraps/neptune/graphistry.yml
+++ b/src/bootstraps/neptune/graphistry.yml
@@ -33,29 +33,42 @@ Parameters:
     Type: String
     Description: "Enter the Neptune Cluster Read Endpoint URL. Ex: abc.def.ghi.neptune.amazonaws.com"
 
-Mappings: 
-  RegionMap: 
-    us-east-1: 
-      "HVM64": "ami-0758d945357560324"
-    us-east-2:
-      "HVM64": "ami-088aaa8746bde2e21"
-    us-west-1: 
-      "HVM64": "ami-041526a3d02947394"
-    us-west-2:
-      "HVM64": "ami-01a5481ca3c8d8257"
-    eu-central-1:
-      "HVM64": "ami-0c3e601ddac853aba"
-    eu-west-1: 
-      "HVM64": "ami-0edc0fc6cb4efa908"
-    eu-west-2:
-      "HVM64": "ami-0f351900207433c32"
-    eu-west-3:
-      "HVM64": "ami-00ee1a79360375598"
+#2.35.9-11.0
+#Generated with: src/bootstraps/scripts/graphistry-ami-list.sh
+Mappings:
+  RegionMap:
     eu-north-1:
-      "HVM64": "ami-0c90b099725351632"
+      "HVM64": "ami-020db5b9468605b1b"
+    ap-south-1:
+      "HVM64": "ami-0da292ae7221b4712"
+    eu-west-3:
+      "HVM64": "ami-097617b9ab348bd7d"
+    eu-west-2:
+      "HVM64": "ami-0fe4d7af59713cc8b"
+    eu-west-1:
+      "HVM64": "ami-04c579438e71c9b4e"
+    ap-northeast-2:
+      "HVM64": "ami-0a647fc9d83aaa798"
+    ap-northeast-1:
+      "HVM64": "ami-09408fd12167b1ddc"
     sa-east-1:
-      "HVM64": "ami-09aa432a1a03a1459"
-
+      "HVM64": "ami-0881a3b8d12b49dd0"
+    ca-central-1:
+      "HVM64": "ami-0046f23296157202d"
+    ap-southeast-1:
+      "HVM64": "ami-04a449007e7a22792"
+    ap-southeast-2:
+      "HVM64": "ami-02a981824c38b66dd"
+    eu-central-1:
+      "HVM64": "ami-010c9a3be1f3ae351"
+    us-east-1:
+      "HVM64": "ami-0322bad99c5e1eec8"
+    us-east-2:
+      "HVM64": "ami-07915b33d57ebde27"
+    us-west-1:
+      "HVM64": "ami-07d59135fe7222642"
+    us-west-2:
+      "HVM64": "ami-0fb7bf940df96836e"
 Resources:
   GraphAppKitSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/src/bootstraps/scripts/graphistry-ami-list.sh
+++ b/src/bootstraps/scripts/graphistry-ami-list.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+###List Graphistry AMIs for yml
+
+AWS=*
+BASE=graphistry-standalone-2???-??-??T??-??-??Z-v
+VERSION=2.35.9-11.0
+SUFFIX=*
+GREP_INCLUDE="aws-marketplace/graphistry-standalone"  # There were some surprise namespaces 
+
+## {"ImageId": ..., "ImageLocation": ..., "region": ...}*
+IMAGES=$( 
+    for region in `aws ec2 describe-regions --output text | cut -f4`
+    do
+        aws ec2 describe-images \
+            --region $region \
+            --owners self 679593333241 \
+            --filters "Name=name,Values=${AWS}${BASE}${VERSION}${SUFFIX}" \
+        | jq -c "(.Images[] | {ImageId: .ImageId, ImageLocation: .ImageLocation, "region": \"$region\"})" \
+        | grep "${GREP_INCLUDE}"
+    done
+)
+
+#echo "IMAGES: $IMAGES"
+#echo "IMAGES: $( echo "$IMAGES" | jq -r . )"
+
+#From ^^^, we want:
+#Mappings: 
+#  RegionMap: 
+#    us-east-1: 
+#      "HVM64": "ami-0758d945357560324"
+for row in `echo "$IMAGES"`; do
+    REGION=$(echo $row | jq -r .region)
+    IMAGE=$(echo $row | jq -r .ImageId)
+    LOC=$(echo $row | jq -r .ImageLocation)
+    echo "${REGION}:"
+    echo "  \"HVM64\": \"$IMAGE\""
+    #echo "  ($LOC)"
+done

--- a/src/bootstraps/scripts/graphistry-service-account.sh
+++ b/src/bootstraps/scripts/graphistry-service-account.sh
@@ -5,21 +5,14 @@ SCRIPT="Get AWS Instance ID"
 ./hello-start.sh "$SCRIPT"
 
 
-ADD_USER_SCRIPT="from nexus.users.models import User; user=User.objects.create_superuser(username='admin', email='admin@amazon.com', password='${INSTANCE_ID}', name='admin', is_active=True); print('made admin')"
-VERIFY_USER_SCRIPT="from allauth.account.models import EmailAddress; e = EmailAddress.objects.create(user=user, email='admin@amazon.com', primary=True, verified=True); e.save(); print('verified admin')"
-POST_SCRIPT="CELERY_BROKER_URL=zz python manage.py shell && echo done || { echo fail && exit 1; }"
-
-## Admin account (user should change on login)
-#FIXME Faster and safer by by a nexus ready check (migrations done => server started?)
+### Graphistry should already add admin / <i-instanceid> on boot
 ( \
     cd "${GRAPHISTRY_HOME}" \
     && ( \
         until ( curl -fsS http://localhost/streamgl-gpu/secondary/gpu/health > /dev/null ); \
         do ( docker-compose ps && sleep 1 ); \
         done \
-    ) && docker-compose exec -T nexus \
-        bash -c \
-          "source activate rapids && echo \"${ADD_USER_SCRIPT}; ${VERIFY_USER_SCRIPT}\" | ${POST_SCRIPT}" \
+    )
 )
 
 ## Service account

--- a/src/bootstraps/scripts/swap-caddy.sh
+++ b/src/bootstraps/scripts/swap-caddy.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
 set -ex
 
+## Graphistry now uses Caddy2, and until Caddy 2 supports simple auth, g-a-k still sticks with Caddy1
+## ... So we stop Graphistry's Caddy 2  and put in a docker-compose of its old
+
 CADDY_FILENAME=${CADDY_FILENAME:-full.Caddyfile}
+CADDY_COMPOSE_FILENAME=${CADDY_COMPOSE_FILENAME:-docker-compose.gak.graphistry.yml}
 
 SCRIPT="Swap Caddyfile"
 ./hello-start.sh "$SCRIPT"
 
 echo "* Using CADDY_FILENAME: $CADDY_FILENAME"
 
+sudo cp "../../caddy/${CADDY_COMPOSE_FILENAME}" "${GRAPHISTRY_HOME}/${CADDY_COMPOSE_FILENAME}"
 sudo cp "../../caddy/${CADDY_FILENAME}" "${GRAPHISTRY_HOME}/data/config/Caddyfile"
 ( \
     cd "${GRAPHISTRY_HOME}" \
-    && sudo docker-compose up -d --force-recreate caddy \
+    && sudo docker-compose stop caddy \
+    && sudo docker-compose -f "${CADDY_COMPOSE_FILENAME}" up -d caddy \
     && sudo docker-compose ps \
+    && sudo docker-compose -f "${CADDY_COMPOSE_FILENAME}" ps \
 )
 
 ./hello-end.sh "$SCRIPT"

--- a/src/caddy/docker-compose.gak.graphistry.yml
+++ b/src/caddy/docker-compose.gak.graphistry.yml
@@ -1,0 +1,44 @@
+#Reuse graphistry's docker-compose setup.. except downgrade to caddy1 for auth support
+#Start _after_ graphistry
+
+networks:
+  grph_net_external:
+    external:
+      name: grph_net
+
+x-production-options:
+  &production_opts
+  restart: unless-stopped
+  expose:
+    - "8080"
+  environment:
+    PORT: 8080
+    NODE_ENV: production
+    USE_LOCAL_USER: "false"
+    ACME_AGREE: "true"
+  networks:
+    - grph_net_external
+
+services:
+  caddy:
+    << : *production_opts
+    image: graphistry/caddy:v2.30.28
+    expose:
+      - "80"
+      - "443"
+    ports:
+      - 80:80
+      - 443:443
+    environment:
+      - ENABLE_TELEMETRY=false
+      - ACME_AGREE=true
+    volumes:
+      - ./data/config/Caddyfile:/etc/Caddyfile
+      - ./data/config/caddy:/root/.caddy
+    healthcheck:
+      interval: 300s
+      start_period: 60s
+      retries: 3
+      timeout: 30s
+      #TODO define local path without muddying Caddyfile
+      test: sh -c 'curl -f http://nginx/healthz'

--- a/src/caddy/docker-compose.gak.graphistry.yml
+++ b/src/caddy/docker-compose.gak.graphistry.yml
@@ -1,6 +1,8 @@
 #Reuse graphistry's docker-compose setup.. except downgrade to caddy1 for auth support
 #Start _after_ graphistry
 
+version: '3.5'
+
 networks:
   grph_net_external:
     external:

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -53,7 +53,7 @@ x-build-kwargs:
   args:
     - DOCKER_TAG=${DOCKER_TAG:-latest}
     - BUILDKIT_INLINE_CACHE=1
-    - GRAPHISTRY_FORGE_BASE_VERSION=v2.35.10-10.2
+    - GRAPHISTRY_FORGE_BASE_VERSION=v2.35.9-11.0
 
 
 ############################################################

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -53,7 +53,7 @@ x-build-kwargs:
   args:
     - DOCKER_TAG=${DOCKER_TAG:-latest}
     - BUILDKIT_INLINE_CACHE=1
-    - GRAPHISTRY_FORGE_BASE_VERSION=v2.33.17
+    - GRAPHISTRY_FORGE_BASE_VERSION=v2.35.10-10.2
 
 
 ############################################################

--- a/src/python/components/Graphistry.py
+++ b/src/python/components/Graphistry.py
@@ -36,7 +36,7 @@ class GraphistrySt:
 
     def plot(self, g):
         if PyGraphistry._is_authenticated:
-            url = g.plot(render=False)
+            url = g.plot(as_files=True, render=False)  # TODO: Remove as_files=True when becomes default
             self.render_url(url)
         else:
 

--- a/src/python/requirements-system.txt
+++ b/src/python/requirements-system.txt
@@ -1,6 +1,6 @@
 streamlit==0.77.0
 protobuf==3.13.0
-graphistry==0.14.0
+graphistry==0.17.2
 
 ################
 #

--- a/src/python/requirements-system.txt
+++ b/src/python/requirements-system.txt
@@ -1,4 +1,4 @@
-streamlit==0.70.0
+streamlit==0.77.0
 protobuf==3.13.0
 graphistry==0.14.0
 
@@ -9,5 +9,5 @@ graphistry==0.14.0
 ################
 
 ### Neptune
-gremlinpython==3.4.8
+gremlinpython==3.4.10
 sshtunnel==0.1.5


### PR DESCRIPTION
Scope:

Graphistry:
  * [x] 2.34+ creates aws admin: Reuse
  * [x] Work around Caddy 2 jwt auth difficulties via Caddy 1 fallback (https://github.com/caddyserver/caddy/issues?page=2&q=is%3Aissue+is%3Aopen + 

General dep updates
- [x] Streamlit
- [x] Graphistry
- [x] Gremlin

Add:
* Changelog