### PR TITLE
infra(publish): add s3 on merge or manual action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,23 @@
 name: Publish
 
 on:
+
+  #Merge
+  push:
+    branches:
+      - master
+
+  #Label
   pull_request:
     types: [labeled]
+
+
+  #Enable UI-driven branch testing
+  workflow_dispatch:
+
+  #Test main bidaily @ 1a
+  schedule:
+    - cron: '0 1 1-31/2 * *'
 
 jobs:
 
@@ -16,7 +31,7 @@ jobs:
 
   publish:
     name: Upload to Amazon S3
-    if: github.event.label.name == 'publish'
+    if: github.event.action != "labaeled" || github.event.label.name == 'publish'
     runs-on: ubuntu-latest
 
     steps:
@@ -36,4 +51,4 @@ jobs:
         aws s3 cp src/bootstraps/core/minimal.yml "s3://${{ secrets.AWS_S3_BUCKET_PUBLIC}}/templates/latest/core/minimal.yml"
         aws s3 cp src/bootstraps/neptune/graphistry.yml "s3://${{ secrets.AWS_S3_BUCKET_PUBLIC}}/templates/latest/neptune/graphistry.yml"
         aws s3 cp src/bootstraps/neptune/minimal.yml "s3://${{ secrets.AWS_S3_BUCKET_PUBLIC}}/templates/latest/neptune/minimal.yml"
-        
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Extensions:
 
 * TigerGraph
 
+### Added
+
+* CI: Publish cloud formaton templates to s3 on merge (https://github.com/graphistry/graph-app-kit/pull/48)
 
 ## [2021.02.23]
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -45,5 +45,4 @@ See [current tags](https://hub.docker.com/repository/docker/graphistry/graph-app
 
 * Docker rebuilds on merge to main
 * Push main tag ('v1.2.3') for building named versions
-* CloudFormation templates upload upon a PR being labeled "publish"
-
+* CloudFormation templates uploaded to S3 upon a PR being labeled "publish", merge-to-main, or explicit GHA call


### PR DESCRIPTION
Infra:
- Publish cloud formation templates to s3 on merge to main or manual GHA trigger, in addition to existing `publish` label

Docs

Should prevent recurrence of https://github.com/graphistry/graph-app-kit/issues/45