### PR TITLE
Dev/graphistry 2 36 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,26 @@ Extensions:
 
 ## [Development]
 
-### Adding
+### Changed
 
-* TigerGraph
+* CI: Graphistry AMI list generator takes VERSION parameter
+* Infra: Upgrade to Graphistry 2.36.6
+
+### Docs
+
+* CI: Graphistry AMI list generator usage
+
+## [2021.03.06]
 
 ### Added
 
-* CI: Publish cloud formaton templates to s3 on merge (https://github.com/graphistry/graph-app-kit/pull/48)
+* CI: Publish cloud formation templates to s3 on merge (https://github.com/graphistry/graph-app-kit/pull/48)
+
+## [2021.02.24]
+
+#### Added
+
+* TigerGraph support (https://github.com/graphistry/graph-app-kit/pull/36)
 
 ## [2021.02.23]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,13 @@ Extensions:
 * [TigerGraph](https://docs.tigergraph.com/faqs/change-log-1)
 * [AWS Neptune](https://docs.aws.amazon.com/neptune/latest/userguide/doc-history.html)
 
-
 ## [Development]
+
+### Adding
+
+See [projects page](https://github.com/graphistry/graph-app-kit/projects) and [open pull requests](https://github.com/graphistry/graph-app-kit/pulls)
+
+## [2021.03.11]
 
 ### Changed
 
@@ -28,6 +33,12 @@ Extensions:
 ### Docs
 
 * CI: Graphistry AMI list generator usage
+* README: Removed dangling link
+* README: Quicklaunch links and admin commands
+
+### Fixed
+
+* Private Streamlit dashboards instance now bound to Jupyter notebook private dashboards folder. Was incorrectly using the public folder: https://github.com/graphistry/graph-app-kit/pull/51/commits/3872de053b7d2888ce271acf395f112491742606
 
 ## [2021.03.06]
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -31,7 +31,7 @@ For faster AWS launches, we:
 - Keep the docker base (docker-compose.yml::GRAPHISTRY_FORGE_BASE_VERSION) in sync w/ AWS version
 
 - Update aws version (bootstraps/*/graphistry.yml) by pointing to that version's region AMIs via bootstraps/scripts/graphistry-ami-list.sh
-  * Run `src/bootstraps/scripts $ VERSION=2.36.6 ./graphistry-ami-list.sh`
+  * Run `src/bootstraps/scripts $ VERSION=2.36.6-11.0 ./graphistry-ami-list.sh`
   * Paste into `src/bootstraps/core,neptune/graphistry.yml`
   * Test via using branch's yml's url, or copy-paste into cloud formation
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -24,12 +24,16 @@ python3 -m pytest test
 
 This is expected to change as full docker-based testing lands
 
-
-## Base versions
+## Aligned base versions
 
 For faster AWS launches, we:
+
 - Keep the docker base (docker-compose.yml::GRAPHISTRY_FORGE_BASE_VERSION) in sync w/ AWS version
-- Update aws version (bootstraps/*/graphistry.yml) by finding AMIs via bootstraps/scripts/graphistry-ami-list.sh
+
+- Update aws version (bootstraps/*/graphistry.yml) by pointing to that version's region AMIs via bootstraps/scripts/graphistry-ami-list.sh
+  * Run `src/bootstraps/scripts $ VERSION=2.36.6 ./graphistry-ami-list.sh`
+  * Paste into `src/bootstraps/core,neptune/graphistry.yml`
+  * Test via using branch's yml's url, or copy-paste into cloud formation
 
 ## Automated Builds
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -12,7 +12,11 @@ docker-compose up
 
 ## Test
 
+### CI
+
 CI will trigger on pushes to PRs
+
+### Local
 
 To test locally:
 
@@ -24,6 +28,12 @@ python3 -m pytest test
 
 This is expected to change as full docker-based testing lands
 
+### AWS
+
+* Modify `src/bootstraps/core/graphistry.yml` on the checkout step do use the branch:  `git clone -b mybranch`
+* Push your branch
+* In CloudFormation, upload your modified `graphistry.yml``
+
 ## Aligned base versions
 
 For faster AWS launches, we:
@@ -33,7 +43,7 @@ For faster AWS launches, we:
 - Update aws version (bootstraps/*/graphistry.yml) by pointing to that version's region AMIs via bootstraps/scripts/graphistry-ami-list.sh
   * Run `src/bootstraps/scripts $ VERSION=2.36.6-11.0 ./graphistry-ami-list.sh`
   * Paste into `src/bootstraps/core,neptune/graphistry.yml`
-  * Test via using branch's yml's url, or copy-paste into cloud formation
+  * Update `src/docker/docker-compose.yml::GRAPHISTRY_FORGE_BASE_VERSION`
 
 ## Automated Builds
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 
 
 
-https://github.com/graphistry/graph-app-kit/issues/39
-
 # Welcome to graph-app-kit
 
 Turn your graph data into a secure and interactive visual graph app in 15 minutes! 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,42 @@ sudo docker-compose up -d --force-recreate
 
 ### Quick Launchers - minimal/full core
 
-1. [Quick launch](docs/setup.md) variants:
-  * [Manual minimal/full](docs/setup-manual.md): 
-  * [Automatic minimal/full](docs/setup.md): 
-  * Database-specific manual/automatic minimal/full: [Amazon Neptune](docs/neptune.md), [TigerGraph](docs/tigergraph.md)
+1. Quick launch options:
+
+**Full**: [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=region#/stacks/new?stackName=graph_app_kit_full&templateURL=https://graph-app-kit-repo-public.s3.us-east-2.amazonaws.com/templates/latest/core/graphistry.yml)
+
+* Public + protected Streamlit dashboards, Jupyter notebooks + editing, Graphistry, RAPIDS
+* Login to web UI as `admin` / `i-instanceid` -> file uploader, notebooks, ...
+* Dashboards: `/public/dash` and `/private/dash`
+* [More info](docs/setup.md)
+
+Admin:
+
+```bash
+# launch logs
+tail -f /var/log/cloud-init-output.log -n 1000
+
+# app logs
+sudo docker ps
+sudo docker logs -f -t --tail=1 MY_CONTAINER
+
+# restart a graphistry container
+cd graphistry && sudo docker-compose restart MY_CONTAINER
+
+# restart caddy (Caddy 1 override)
+cd graphistry && sudo docker-compose -f docker-compose.gak.graphistry.yml up -d caddy
+
+# run streamlit
+cd graph-app-kit/public/graph-app-kit && docker-compose -p pub run -d --name streamlit-pub streamlit
+cd graph-app-kit/private/graph-app-kit && docker-compose -p priv run -d --name streamlit-priv streamlit
+```
+
+**Minimal**: Open Streamlit, ssh to connect/add [free Graphistry Hub username/pass](https://www.graphistry.com/get-started):
+
+**Database-specific**: [Amazon Neptune](docs/neptune.md), [TigerGraph](docs/tigergraph.md)
+
 2. [Add views](docs/views.md)
+
 3. [Main configurations and extensions](docs/extend.md): Database connectors, authentication, notebook-based editing, and more
 
 ## The pieces

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,7 +27,6 @@ Steps:
   *  If AWS reports `Please select another region`, use the `Select a Region` dropdown in the top right menu.
  
 
-
 Launches:
 
   * AWS CPU-mode instance + hub.graphistry.com account
@@ -102,6 +101,47 @@ Go to your public Streamlit dashboard and start exploring: http://[the.public.ip
   * Installed at `/home/ubuntu/graph-app-kit/public/graph-app-kit`
   * Run as `src/docker $ docker-compose up -d streamlit`
 
-## 4. Next steps
+## 4. Optional - administer
+
+Advanced users can SSH into the server to manipulate individual services:
+
+### System visibility
+
+```bash
+# launch logs
+tail -f /var/log/cloud-init-output.log -n 1000
+
+# app logs
+sudo docker ps
+sudo docker logs -f -t --tail=1 MY_CONTAINER
+
+# stats
+sudo htop
+sudo iftop
+top
+```
+
+### Graphistry
+
+For more advanced Graphistry administration, so the [Graphistry admin docs repo](https://github.com/graphistry/graphistry-cli)
+
+```bash
+# restart a graphistry container
+cd graphistry && sudo docker-compose restart MY_CONTAINER  # do *not* run it's caddy (v2)
+
+# restart caddy (Caddy 1 override over Graphistry's Caddy 2)
+cd graphistry && sudo docker-compose -f docker-compose.gak.graphistry.yml up -d caddy
+```
+
+### Streamlit
+
+Use `docker-compose` project names (`-p the_name`) to distinguish your public vs private dashboards:
+
+```bash
+cd graph-app-kit/public/graph-app-kit && docker-compose -p pub run -d --name streamlit-pub streamlit
+cd graph-app-kit/private/graph-app-kit && docker-compose -p priv run -d --name streamlit-priv streamlit
+```
+
+## 5. Next steps
 
 Continue to the instructions for [creating custom views](views.md) and [adding common extensions](extend.md) like TLS, public/private dashboards, and more

--- a/src/bootstraps/core/graphistry.sh
+++ b/src/bootstraps/core/graphistry.sh
@@ -36,7 +36,6 @@ echo "Got SERVICE_USER ${SERVICE_USER}, SERVICE_PASS"
 echo '===== Configuring graph-app-kit with Graphistry service account and Neptune ====='
 ( \
     cd ../../docker \
-    && echo "GRAPH_VIEWS=${GRAPHISTRY_HOME}/data/notebooks/graph-app-kit/public/views" \
     && echo "GRAPHISTRY_USERNAME=${SERVICE_USER}" \
     && echo "GRAPHISTRY_PASSWORD=${SERVICE_PASS}" \
     && echo "GRAPHISTRY_PROTOCOL=http" \
@@ -47,8 +46,14 @@ echo '----- Reuse public graph-app-kit .env as private .env'
 sudo cp "${GAK_PUBLIC}/src/docker/.env" "${GAK_PRIVATE}/src/docker/.env"
 
 echo '----- Finish pub vs. priv .env specialization'
-echo "BASE_PATH=public/dash/" | sudo tee -a "${GAK_PUBLIC}/src/docker/.env"
-echo "BASE_PATH=private/dash/" | sudo tee -a "${GAK_PRIVATE}/src/docker/.env"
+( \
+  echo "BASE_PATH=public/dash/"  \
+  && echo "GRAPH_VIEWS=${GRAPHISTRY_HOME}/data/notebooks/graph-app-kit/public/views" \
+) | sudo tee -a "${GAK_PUBLIC}/src/docker/.env"
+( \
+  echo "BASE_PATH=private/dash/"  \
+  && echo "GRAPH_VIEWS=${GRAPHISTRY_HOME}/data/notebooks/graph-app-kit/private/views" \
+) | sudo tee -a "${GAK_PRIVATE}/src/docker/.env"
 
 echo '----- Launching graph-app-kit as streamlit-pub/priv:8501'
 ( \

--- a/src/bootstraps/core/graphistry.yml
+++ b/src/bootstraps/core/graphistry.yml
@@ -35,37 +35,37 @@ Parameters:
 Mappings: 
   RegionMap: 
     eu-north-1:
-      "HVM64": "ami-020db5b9468605b1b"
+      "HVM64": "ami-007f7e0cbb31804ca"
     ap-south-1:
-      "HVM64": "ami-0da292ae7221b4712"
+      "HVM64": "ami-0771ea144a8bcc05b"
     eu-west-3:
-      "HVM64": "ami-097617b9ab348bd7d"
+      "HVM64": "ami-0bf29fec2ad97b43b"
     eu-west-2:
-      "HVM64": "ami-0fe4d7af59713cc8b"
+      "HVM64": "ami-03801ca4648205427"
     eu-west-1:
-      "HVM64": "ami-04c579438e71c9b4e"
+      "HVM64": "ami-0bcd749f1d0a1dfe6"
     ap-northeast-2:
-      "HVM64": "ami-0a647fc9d83aaa798"
+      "HVM64": "ami-0851b639bbe404677"
     ap-northeast-1:
-      "HVM64": "ami-09408fd12167b1ddc"
+      "HVM64": "ami-007b0de4d538562dc"
     sa-east-1:
-      "HVM64": "ami-0881a3b8d12b49dd0"
+      "HVM64": "ami-0ef63be746e7a24bc"
     ca-central-1:
-      "HVM64": "ami-0046f23296157202d"
+      "HVM64": "ami-05183e0beb7303c26"
     ap-southeast-1:
-      "HVM64": "ami-04a449007e7a22792"
+      "HVM64": "ami-0a5195b33c77678be"
     ap-southeast-2:
-      "HVM64": "ami-02a981824c38b66dd"
+      "HVM64": "ami-0f89327925bd9a8ea"
     eu-central-1:
-      "HVM64": "ami-010c9a3be1f3ae351"
+      "HVM64": "ami-0103e61885346f05f"
     us-east-1:
-      "HVM64": "ami-0322bad99c5e1eec8"
+      "HVM64": "ami-0a6659acaf427e811"
     us-east-2:
-      "HVM64": "ami-07915b33d57ebde27"
+      "HVM64": "ami-04b7d03027f1bf5d0"
     us-west-1:
-      "HVM64": "ami-07d59135fe7222642"
+      "HVM64": "ami-08e1eb5246688bfa2"
     us-west-2:
-      "HVM64": "ami-0fb7bf940df96836e"
+      "HVM64": "ami-033ef56997e62c46b"
 
 Resources:
   GraphAppKitSecurityGroup:

--- a/src/bootstraps/core/graphistry.yml
+++ b/src/bootstraps/core/graphistry.yml
@@ -30,7 +30,7 @@ Parameters:
     Default: 'g4dn.xlarge'
     Description: "Enter a RAPIDS.ai-compatible GPU instance type. Ex: g4dn.xlarge"
 
-#2.35.9-11.0
+#2.36.6-11.0
 #Generated with: src/bootstraps/scripts/graphistry-ami-list.sh
 Mappings: 
   RegionMap: 

--- a/src/bootstraps/neptune/graphistry.yml
+++ b/src/bootstraps/neptune/graphistry.yml
@@ -33,7 +33,7 @@ Parameters:
     Type: String
     Description: "Enter the Neptune Cluster Read Endpoint URL. Ex: abc.def.ghi.neptune.amazonaws.com"
 
-#2.35.9-11.0
+#2.36.6-11.0
 #Generated with: src/bootstraps/scripts/graphistry-ami-list.sh
 Mappings:
   RegionMap:

--- a/src/bootstraps/neptune/graphistry.yml
+++ b/src/bootstraps/neptune/graphistry.yml
@@ -38,37 +38,37 @@ Parameters:
 Mappings:
   RegionMap:
     eu-north-1:
-      "HVM64": "ami-020db5b9468605b1b"
+      "HVM64": "ami-007f7e0cbb31804ca"
     ap-south-1:
-      "HVM64": "ami-0da292ae7221b4712"
+      "HVM64": "ami-0771ea144a8bcc05b"
     eu-west-3:
-      "HVM64": "ami-097617b9ab348bd7d"
+      "HVM64": "ami-0bf29fec2ad97b43b"
     eu-west-2:
-      "HVM64": "ami-0fe4d7af59713cc8b"
+      "HVM64": "ami-03801ca4648205427"
     eu-west-1:
-      "HVM64": "ami-04c579438e71c9b4e"
+      "HVM64": "ami-0bcd749f1d0a1dfe6"
     ap-northeast-2:
-      "HVM64": "ami-0a647fc9d83aaa798"
+      "HVM64": "ami-0851b639bbe404677"
     ap-northeast-1:
-      "HVM64": "ami-09408fd12167b1ddc"
+      "HVM64": "ami-007b0de4d538562dc"
     sa-east-1:
-      "HVM64": "ami-0881a3b8d12b49dd0"
+      "HVM64": "ami-0ef63be746e7a24bc"
     ca-central-1:
-      "HVM64": "ami-0046f23296157202d"
+      "HVM64": "ami-05183e0beb7303c26"
     ap-southeast-1:
-      "HVM64": "ami-04a449007e7a22792"
+      "HVM64": "ami-0a5195b33c77678be"
     ap-southeast-2:
-      "HVM64": "ami-02a981824c38b66dd"
+      "HVM64": "ami-0f89327925bd9a8ea"
     eu-central-1:
-      "HVM64": "ami-010c9a3be1f3ae351"
+      "HVM64": "ami-0103e61885346f05f"
     us-east-1:
-      "HVM64": "ami-0322bad99c5e1eec8"
+      "HVM64": "ami-0a6659acaf427e811"
     us-east-2:
-      "HVM64": "ami-07915b33d57ebde27"
+      "HVM64": "ami-04b7d03027f1bf5d0"
     us-west-1:
-      "HVM64": "ami-07d59135fe7222642"
+      "HVM64": "ami-08e1eb5246688bfa2"
     us-west-2:
-      "HVM64": "ami-0fb7bf940df96836e"
+      "HVM64": "ami-033ef56997e62c46b"
 Resources:
   GraphAppKitSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/src/bootstraps/scripts/graphistry-ami-list.sh
+++ b/src/bootstraps/scripts/graphistry-ami-list.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 set -e
 
-###List Graphistry AMIs for yml
+#
+# List Graphistry AMIs for yml
+#
+# Run: $ VERSION=2.36.6 ./graphistry-ami-list.sh
+#
+# Output: Non-zero return code on failure, and on success:
+#
+#eu-north-1:
+#  "HVM64": "ami-007f7e0cbb31804ca"
+#ap-south-1:
+#  "HVM64": "ami-0771ea144a8bcc05b"
+#eu-west-3:
+#  "HVM64": "ami-0bf29fec2ad97b43b"
+# ...
+#
+# ------------
 
 AWS=*
 BASE=graphistry-standalone-2???-??-??T??-??-??Z-v
-VERSION=2.35.9-11.0
+VERSION=${VERSION:-2.35.9-11.0}
 SUFFIX=*
 GREP_INCLUDE="aws-marketplace/graphistry-standalone"  # There were some surprise namespaces 
 

--- a/src/bootstraps/scripts/graphistry-ami-list.sh
+++ b/src/bootstraps/scripts/graphistry-ami-list.sh
@@ -4,7 +4,7 @@ set -e
 #
 # List Graphistry AMIs for yml
 #
-# Run: $ VERSION=2.36.6 ./graphistry-ami-list.sh
+# Run: $ VERSION=2.36.6-11.0 ./graphistry-ami-list.sh
 #
 # Output: Non-zero return code on failure, and on success:
 #

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -54,7 +54,7 @@ x-build-kwargs:
   args:
     - DOCKER_TAG=${DOCKER_TAG:-latest}
     - BUILDKIT_INLINE_CACHE=1
-    - GRAPHISTRY_FORGE_BASE_VERSION=v2.35.9-11.0
+    - GRAPHISTRY_FORGE_BASE_VERSION=${GRAPHISTRY_FORGE_BASE_VERSION:-v2.36.6-11.0}
 
 
 ############################################################


### PR DESCRIPTION
Infra:
* AMI list gen takes parameter VERSION=2.36.6-11.0
* Update graphistry base to 2.36.6-11.0

Docs:
* AMI list gen
* changelog
* README cleanup: dangling link, more quick launch + first commands
* Admin commands

Fix:
* Private streamlit was mounting public dashes