### PR TITLE
Pyg upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ Extensions:
 
 See [projects page](https://github.com/graphistry/graph-app-kit/projects) and [open pull requests](https://github.com/graphistry/graph-app-kit/pulls)
 
+## [2022.03.13]
+
+### Changed
+
+* GraphistrySt: Switched from unsafe mode markdown to component
+* PyGraphistry: Updated to 0.21.2
+
+### Breaking
+
+* UI: Switch default to wide mode
+
+
 ## [2022.03.02]
 
 ### Changed

--- a/src/python/components/Graphistry.py
+++ b/src/python/components/Graphistry.py
@@ -1,4 +1,4 @@
-import graphistry, os, streamlit as st
+import graphistry, os, streamlit as st, streamlit.components.v1 as components
 from graphistry import PyGraphistry
 
 from util import getChild
@@ -33,8 +33,13 @@ class GraphistrySt:
     def render_url(self, url):
         if self.test_login():
             logger.debug('rendering main area, with url: %s', url)
-            iframe = '<iframe src="' + url + '", height="800", width="100%" allow="fullscreen"></iframe>'
-            st.markdown(iframe, unsafe_allow_html=True)
+            #iframe = '<iframe src="' + url + '", height="800", width="100%" style="position: absolute" allow="fullscreen"></iframe>'
+            #st.markdown(iframe, unsafe_allow_html=True)
+            components.iframe(
+                src=url,
+                height=800,
+                scrolling=True
+            )
 
     def plot(self, g):
         if PyGraphistry._is_authenticated:

--- a/src/python/entrypoint.py
+++ b/src/python/entrypoint.py
@@ -3,7 +3,7 @@ from components import AppPicker
 
 page_title_str = "Graph dashboard"
 st.set_page_config(
-    layout="centered",  # Can be "centered" or "wide". In the future also "dashboard", etc.
+    layout="wide",  # Can be "centered" or "wide". In the future also "dashboard", etc.
     initial_sidebar_state="auto",  # Can be "auto", "expanded", "collapsed"
     page_title=page_title_str,  # String or None. Strings get appended with "• Streamlit".
     page_icon='none.png',  # String, anything supported by st.image, or None.

--- a/src/python/requirements-system.txt
+++ b/src/python/requirements-system.txt
@@ -1,6 +1,6 @@
 streamlit==1.6.0
 protobuf==3.18
-graphistry==0.20.5
+graphistry==0.21.2
 
 ################
 #


### PR DESCRIPTION
### Changed

* GraphistrySt: Switched from unsafe mode markdown to component
* PyGraphistry: Updated to 0.21.2

### Breaking

* UI: Switch default to wide mode
