### PR TITLE
Dual CUDA build (11.8/12.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, 3.10 ]
+        python-version: [ "3.8", "3.9", "3.10" ]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
     strategy:
       matrix:
         flavor: [ 'dc', 'dc.cpu' ]
-        CUDA_SHORT_VERSION: ['12.8', '11.8']
 
     steps:
 
@@ -72,7 +71,6 @@ jobs:
     - name: get most recent tag
       run: |
         echo "RELEASE_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-        echo "CUDA_SHORT_VERSION=${{ matrix.CUDA_SHORT_VERSION }}" >> $GITHUB_ENV
 
     - name: Free Disk Space
       env:
@@ -224,6 +222,6 @@ jobs:
       env:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
-          GRAPHISTRY_FORGE_BASE_VERSION: v${{ env.RELEASE_VERSION }}-${{ env.CUDA_SHORT_VERSION }}
+          GRAPHISTRY_FORGE_BASE_VERSION: v${{ env.RELEASE_VERSION }}-12.8
       run: |
         cd src/docker && ./${{ matrix.flavor }} build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,19 @@ jobs:
     strategy:
       matrix:
         flavor: [ 'dc', 'dc.cpu' ]
+        CUDA_SHORT_VERSION: ['12.8', '11.8']
 
     steps:
 
     - name: Checkout repo
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: get most recent tag
+      run: |
+        echo "RELEASE_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+        echo "CUDA_SHORT_VERSION=${{ matrix.CUDA_SHORT_VERSION }}" >> $GITHUB_ENV
 
     - name: Free Disk Space
       env:
@@ -216,5 +224,6 @@ jobs:
       env:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
+          GRAPHISTRY_FORGE_BASE_VERSION: v${{ env.RELEASE_VERSION }}-${{ env.CUDA_SHORT_VERSION }}
       run: |
         cd src/docker && ./${{ matrix.flavor }} build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.8, 3.9, 3.10 ]
 
     steps:
 

--- a/.github/workflows/dockerhubpublish.yml
+++ b/.github/workflows/dockerhubpublish.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     strategy:
       matrix:
-        CUDA_SHORT_VERSION: ['12.8']
+        CUDA_SHORT_VERSION: ['12.8', '11.8']
       fail-fast: true
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ See [projects page](https://github.com/graphistry/graph-app-kit/projects) and [o
 * Local development defaults to CUDA 12.8 with ability to override via environment variables
 * Updated CI Python test matrix from [3.7, 3.8, 3.9] to [3.8, 3.9, 3.10] for Ubuntu 24.04 compatibility
 
+### Fixes
+
+* Fix graph-app-kit dependency conflicts by upgrading streamlit to 1.38.0 (protobuf 5.x support) and removing duplicate graphistry requirement already provided by base image
+* Fix conda environment name from "rapids" to "base" for RAPIDS 25.02 compatibility
+* Update graph-app-kit CI test-docker job to use dynamic base image versioning with dual CUDA support (11.8/12.8) matching the publish workflow
+
 ### Notes
 
 * Enterprise customers can choose appropriate CUDA version based on their GPU hardware

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ See [projects page](https://github.com/graphistry/graph-app-kit/projects) and [o
 * Fix graph-app-kit dependency conflicts by upgrading streamlit to 1.38.0 (protobuf 5.x support) and removing duplicate graphistry requirement already provided by base image
 * Fix conda environment name from "rapids" to "base" for RAPIDS 25.02 compatibility
 * Update graph-app-kit CI test-docker job to use dynamic base image versioning matching the publish workflow
+* Replace deprecated streamlit experimental query params API (st.experimental_get_query_params/st.experimental_set_query_params) with new st.query_params API and fix data structure compatibility issues
+* Fix Neptune demo connection errors by adding proper null checking for gremlin_helper.connect_to_neptune() return values
+* Update FunCoup bio demo to use FC6.0 data source with new URL structure and column mapping for compatibility
+* Add data size limiting (50k edges max) and 502 Bad Gateway error handling for large datasets in bio demos
+* Fix dropdown selection issues in AppPicker by removing unnecessary query parameter updates and widget keys
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ See [projects page](https://github.com/graphistry/graph-app-kit/projects) and [o
 
 * Fix graph-app-kit dependency conflicts by upgrading streamlit to 1.38.0 (protobuf 5.x support) and removing duplicate graphistry requirement already provided by base image
 * Fix conda environment name from "rapids" to "base" for RAPIDS 25.02 compatibility
-* Update graph-app-kit CI test-docker job to use dynamic base image versioning with dual CUDA support (11.8/12.8) matching the publish workflow
+* Update graph-app-kit CI test-docker job to use dynamic base image versioning matching the publish workflow
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ See [projects page](https://github.com/graphistry/graph-app-kit/projects) and [o
   - Example: `graphistry/graph-app-kit-st:v2.43.6-12.8` and `graphistry/graph-app-kit-st:v2.43.6-11.8`
 * Build process uses `GRAPHISTRY_FORGE_BASE_VERSION` environment variable override from parent Graphistry CI/CD
 * Local development defaults to CUDA 12.8 with ability to override via environment variables
+* Updated CI Python test matrix from [3.7, 3.8, 3.9] to [3.8, 3.9, 3.10] for Ubuntu 24.04 compatibility
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ Extensions:
 See [projects page](https://github.com/graphistry/graph-app-kit/projects) and [open pull requests](https://github.com/graphistry/graph-app-kit/pulls)
 
 
+## [2.43.6 - 2025.08.21]
+
+### Infra
+
+* Added dual CUDA build support in CI/CD pipeline
+* Modified `.github/workflows/dockerhubpublish.yml` to use matrix strategy for CUDA versions ['12.8', '11.8']
+* Docker images now automatically built and tagged with CUDA version suffix for both versions
+  - Example: `graphistry/graph-app-kit-st:v2.43.6-12.8` and `graphistry/graph-app-kit-st:v2.43.6-11.8`
+* Build process uses `GRAPHISTRY_FORGE_BASE_VERSION` environment variable override from parent Graphistry CI/CD
+* Local development defaults to CUDA 12.8 with ability to override via environment variables
+
+### Notes
+
+* Enterprise customers can choose appropriate CUDA version based on their GPU hardware
+  - CUDA 11.8: Legacy GPU support (V100, RTX series)
+  - CUDA 12.8: Latest GPU features (H100, Blackwell)
+* No breaking changes - existing deployments continue with CUDA 12.8 default
+
+
 ## [2.43.1 - 2025.07.07]
 
 ### Infra 

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -16,15 +16,15 @@ EXPOSE 8501
 WORKDIR /app
 
 COPY python/conda-app.sh ./
-RUN { source activate rapids || echo ok ; } && ./conda-app.sh
+RUN { source activate base || echo ok ; } && ./conda-app.sh
 
 COPY python/requirements-system.txt ./
 RUN --mount=type=cache,target=/root/.cache \
-    { source activate rapids || echo ok ; } && pip install -r requirements-system.txt
+    { source activate base || echo ok ; } && pip install -r requirements-system.txt
 
 COPY python/requirements-app.txt ./
 RUN --mount=type=cache,target=/root/.cache  \
-    { source activate rapids || echo ok ; } && pip install -r requirements-app.txt
+    { source activate base || echo ok ; } && pip install -r requirements-app.txt
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/src/python/components/URLParam.py
+++ b/src/python/components/URLParam.py
@@ -14,8 +14,8 @@ class URLParam:
     # str * 'a -> 'a
     def get_field(self, field: str, default=None):
         field = self.prefix + field
-        query_params = st.experimental_get_query_params()
-        maybe_v = json.loads(urllib.parse.unquote(query_params[field][0])) if field in query_params else None
+        query_params = st.query_params.to_dict()
+        maybe_v = json.loads(urllib.parse.unquote(query_params[field])) if field in query_params else None
         out = default if maybe_v is None else maybe_v
         logger.debug("resolved default for %s as %s :: %s", field, out, type(out))
         return out
@@ -23,10 +23,12 @@ class URLParam:
     # str * 'a -> ()
     def set_field(self, field: str, val):
         field = self.prefix + field
-        query_params = st.experimental_get_query_params()
+        query_params = st.query_params.to_dict()
         logger.debug("params at set: %s", query_params.items())
         logger.debug("rewriting field %s val %s as %s", field, val, urllib.parse.quote(json.dumps(val), safe=""))
 
-        query_params = st.experimental_set_query_params(
-            **{**{k: v[0] for k, v in query_params.items()}, **{field: urllib.parse.quote(json.dumps(val), safe="")}}
-        )
+        new_value = urllib.parse.quote(json.dumps(val), safe="")
+        # Only update if the value has changed to prevent infinite loops
+        if field not in query_params or query_params[field] != new_value:
+            new_params = {**{k: v for k, v in query_params.items()}, **{field: new_value}}
+            st.query_params.from_dict(new_params)

--- a/src/python/requirements-system.txt
+++ b/src/python/requirements-system.txt
@@ -1,5 +1,5 @@
-graphistry==0.33.8
-streamlit==1.25.0
+streamlit==1.38.0
+protobuf==5.29.3
 
 ################
 #

--- a/src/python/views/demo_avr/__init__.py
+++ b/src/python/views/demo_avr/__init__.py
@@ -136,7 +136,7 @@ def sidebar_area(cluster_id, general_probability, cluster_select_values):
     )
 
     # Query parameters from a shared URL
-    query_params: Dict[str, Any] = st.experimental_get_query_params()
+    query_params: Dict[str, Any] = st.query_params.to_dict()
 
     # Finally, set any query params that have changed
     logger.debug(f"Almost final query_params: {query_params}\n")
@@ -151,7 +151,7 @@ def sidebar_area(cluster_id, general_probability, cluster_select_values):
         query_params.pop("general_probability")
 
     logger.debug(f"Final query_params: {query_params}\n")
-    st.experimental_set_query_params(**query_params)
+    st.query_params.from_dict(query_params)
 
     return {
         "cluster_id": cluster_id,
@@ -259,7 +259,7 @@ def run_all():
             splunk_client: Union[SplunkConnection, Any] = cache_splunk_client(splunk_username, splunk_password, splunk_host)
 
             # Query parameters from a shared URL
-            query_params: Dict[str, Any] = st.experimental_get_query_params()
+            query_params: Dict[str, Any] = st.query_params.to_dict()
 
             # Log what we got
             logger.debug(f"Initial query_params: {query_params}\n")

--- a/src/python/views/demo_neptune_01_minimal_gremlin/__init__.py
+++ b/src/python/views/demo_neptune_01_minimal_gremlin/__init__.py
@@ -118,7 +118,11 @@ def path_to_df(p):
 #@st.cache(suppress_st_warning=True, allow_output_mutation=True)
 @st.cache_data
 def run_filters(num_edges):
-    g, conn = gremlin_helper.connect_to_neptune()
+    result = gremlin_helper.connect_to_neptune()
+    if result is None:
+        st.error("Neptune connection not configured. Please set NEPTUNE_READER_HOST, NEPTUNE_READER_PORT, and NEPTUNE_READER_PROTOCOL environment variables.")
+        return {'nodes_df': None, 'edges_df': None, 'url': None}
+    g, conn = result
 
     logger.info('Querying neptune')
     res = g.V().inE().limit(num_edges).outV().path().by(

--- a/src/python/views/demo_neptune_02_gremlin/__init__.py
+++ b/src/python/views/demo_neptune_02_gremlin/__init__.py
@@ -192,7 +192,11 @@ def path_to_df(p):
 @st.cache_data
 def run_filters(num_edges, state, city):
     global metrics
-    g, conn = gremlin_helper.connect_to_neptune()
+    result = gremlin_helper.connect_to_neptune()
+    if result is None:
+        st.error("Neptune connection not configured. Please set NEPTUNE_READER_HOST, NEPTUNE_READER_PORT, and NEPTUNE_READER_PROTOCOL environment variables.")
+        return {'nodes_df': None, 'edges_df': None, 'url': None}
+    g, conn = result
 
     logger.info('Querying neptune')
     tic = time.perf_counter()

--- a/src/python/views/demo_neptune_03_c360/__init__.py
+++ b/src/python/views/demo_neptune_03_c360/__init__.py
@@ -140,7 +140,11 @@ def path_to_df(p):
 @st.cache_data
 def run_filters(num_edges, num_matches, transient_id):
     global metrics
-    g, conn = gremlin_helper.connect_to_neptune()
+    result = gremlin_helper.connect_to_neptune()
+    if result is None:
+        st.error("Neptune connection not configured. Please set NEPTUNE_READER_HOST, NEPTUNE_READER_PORT, and NEPTUNE_READER_PROTOCOL environment variables.")
+        return {'nodes_df': None, 'edges_df': None, 'url': None}
+    g, conn = result
 
     logger.info('Querying neptune')
     tic = time.perf_counter()


### PR DESCRIPTION
This pull request implements dual CUDA build support and upgrades the Python stack for RAPIDS 25.02 compatibility. The changes enable automatic building of graph-app-kit Docker images for both CUDA 11.8 and 12.8, while resolving critical dependency conflicts and
runtime issues.

**Infrastructure Changes**

Dual CUDA Build Support: Modified CI/CD pipeline to use matrix strategy for building Docker images with both CUDA 11.8 and 12.8 versions. Images are automatically tagged with CUDA version suffix (e.g., v2.43.6-12.8, v2.43.6-11.8).

Python Environment Updates: Updated CI test matrix from Python 3.7-3.9 to 3.8-3.10 for Ubuntu 24.04 compatibility. Fixed conda environment reference from `rapids` to `base` for RAPIDS 25.02

**Dependency Resolution**

Streamlit Upgrade: Migrated from streamlit 1.25.0 to 1.38.0 to resolve protobuf dependency conflicts. RAPIDS 25.02 requires protobuf 5.x while streamlit 1.25.0 was incompatible with this requirement.

API Migration: Updated deprecated streamlit experimental query parameters API to stable `st.query_params` API, including data structure compatibility fixes.

**Application Fixes**

Neptune Demos: Added proper null checking for Neptune connection handling to prevent runtime crashes when connection configuration is missing.

`FunCoup` Integration: Updated bio demo to use `FC6.0` data source with new URL structure and column mapping. Added data size limiting (`50k` edges max) and `502` Bad Gateway error handling for large datasets.

UI Improvements: Fixed dropdown selection issues in `AppPicker` by removing unnecessary widget keys and preventing infinite query parameter update loops.

**Technical Details**

- Docker images support both legacy (V100, RTX) and modern (H100, Blackwell) GPU architectures.
- Maintains backward compatibility with existing deployments defaulting to CUDA 12.8
- Implements fallback mechanisms for external data source failures.
- Includes improved error handling for visualization upload limits.