### PR TITLE
build(deps): upgrade streamlit 1.38.0 -> 1.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,20 @@ Extensions:
 
 See [projects page](https://github.com/graphistry/graph-app-kit/projects) and [open pull requests](https://github.com/graphistry/graph-app-kit/pulls)
 
+## [2.50.5 - 2026.05.21]
+
 ### Infra
 
 * Add configurable `cuda_versions` input parameter to DockerHub publish workflow for flexible CI builds
 * CUDA versions can now be passed as a JSON array (e.g., `'["12.8", "11.8"]'`) when triggering workflow manually or from other workflows
+* upgrade from streamlit v1.38.0 to latest --> v1.57.0
+* remove obsolete protobuf v5.29.3 pin; protobuf is now inherited from the base image (the pin conflicted with the base grpcio-status, which requires protobuf >=6.30.0)
 
 ### Fixes
 
 * Change conda environment activation from `rapids` to `base` for compatibility with newer RAPIDS versions
 * Fix `AttributeError` when `LOG_LEVEL=TRACE` by mapping unsupported log levels (TRACE, VERBOSE) to DEBUG with stderr warning
+* Give the AppPicker view-selector `selectbox` a collapsed accessibility label; streamlit 1.57.0 logs a stack-trace warning for empty widget labels
 
 
 ## [2.43.6 - 2025.08.21]

--- a/src/python/components/AppPicker.py
+++ b/src/python/components/AppPicker.py
@@ -124,10 +124,11 @@ class AppPicker:
                 logger.debug("AppPicker: options=%s, maybe_default_view_id=%s, default_index=%s",
                             options, maybe_default_view_id, default_index)
                 view_id = st.sidebar.selectbox(
-                    "",
+                    "Select view",
                     options,
                     index=default_index,
-                    format_func=(lambda id: modules_by_id[id]["name"].upper())
+                    format_func=(lambda id: modules_by_id[id]["name"].upper()),
+                    label_visibility="collapsed",
                 )
                 view = modules_by_id[view_id]
                 # Only update query params if the view has actually changed

--- a/src/python/requirements-system.txt
+++ b/src/python/requirements-system.txt
@@ -1,5 +1,4 @@
-streamlit==1.38.0
-protobuf==5.29.3
+streamlit==1.57.0
 
 ################
 #


### PR DESCRIPTION
- drop obsolete protobuf pin; protobuf is provided by the base image (the pin conflicted with the base grpcio-status)
- AppPicker: give the view-selector selectbox a collapsed accessibility label (streamlit 1.57.0 logs a warning for empty widget labels)